### PR TITLE
[Babel] Pass through `modules` option for the ES2015 preset

### DIFF
--- a/babel-preset-r29/CHANGELOG.md
+++ b/babel-preset-r29/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0 (September 21, 2017)
+
+* Allow [modules](https://babeljs.io/docs/plugins/preset-es2015/#optionsmodules) ES2015 option to be passed through
+
 ## 1.0.0 (September 12, 2017)
 
 * First release

--- a/babel-preset-r29/README.md
+++ b/babel-preset-r29/README.md
@@ -33,3 +33,30 @@ require("babel-core").transform("code", {
   presets: ["r29"]
 });
 ```
+
+### Supported options
+#### modules
+`"amd" | "umd" | "systemjs" | "commonjs" | false`, defaults to "commonjs".
+
+Enable transformation of ES6 module syntax to another module type.
+
+Setting this to false will not transform modules. Use this for Webpack 2,
+since Webpack 2's tree-shaking works best if you don't transform `import`/`export`
+statements.
+
+Example of a Webpack config where this is the case:
+```js
+{
+  test: /\.js$/,
+  use: {
+    loader: 'babel-loader',
+    options: {
+      presets: [
+        ['r29', { modules: false }],
+      ],
+      plugins: []
+    }
+  },
+  exclude: /node_modules/
+}
+```

--- a/babel-preset-r29/index.js
+++ b/babel-preset-r29/index.js
@@ -1,6 +1,13 @@
 'use strict';
 
-module.exports = {
-  "presets": ["es2015", "react", "stage-3"],
-  "plugins": ["transform-class-properties"]
+module.exports = function (context, opts = {}) {
+  var es2015 = ['es2015', {}];
+  if (opts.modules !== undefined) {
+    es2015[1].modules = opts.modules;
+  }
+
+  return {
+    presets: [es2015, "react", "stage-3"],
+    plugins: ["transform-class-properties"]
+  };
 };

--- a/babel-preset-r29/package.json
+++ b/babel-preset-r29/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-r29",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Babel preset for Refinery29",
   "main": "index.js",
   "repository": "https://github.com/refinery29/js-standards/tree/master/babel-preset-r29",


### PR DESCRIPTION
Being able to turn off the transpilation of `import`/`export` to commonjs is necessary for Webpack 2's Tree Shaking to work.

Source: http://jakewiesler.com/tree-shaking-es6-modules-in-webpack-2/

This is currently accomplished with the `{modules: false}` option to ES2015.

We should allow our apps to pass that through.