### PR TITLE
[Babel] Pass through `loose` option for the ES2015 preset

### DIFF
--- a/babel-preset-r29/CHANGELOG.md
+++ b/babel-preset-r29/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0 (September 22, 2017)
+
+* Allow [loose](https://babeljs.io/docs/plugins/preset-es2015/#optionsloose) ES2015 option to be passed through
+  - http://2ality.com/2015/12/babel6-loose-mode.html
+
 ## 1.1.0 (September 21, 2017)
 
 * Allow [modules](https://babeljs.io/docs/plugins/preset-es2015/#optionsmodules) ES2015 option to be passed through

--- a/babel-preset-r29/README.md
+++ b/babel-preset-r29/README.md
@@ -35,6 +35,14 @@ require("babel-core").transform("code", {
 ```
 
 ### Supported options
+#### loose
+`boolean`, defaults to `false`.
+
+Turns on the ES2015 plugin's loose mode.
+http://2ality.com/2015/12/babel6-loose-mode.html
+
+In practice we have found that this can reduce bundle size by ~5%.
+
 #### modules
 `"amd" | "umd" | "systemjs" | "commonjs" | false`, defaults to "commonjs".
 

--- a/babel-preset-r29/index.js
+++ b/babel-preset-r29/index.js
@@ -5,6 +5,9 @@ module.exports = function (context, opts = {}) {
   if (opts.modules !== undefined) {
     es2015[1].modules = opts.modules;
   }
+  if (opts.loose !== undefined) {
+    es2015[1].loose = opts.loose;
+  }
 
   return {
     presets: [es2015, "react", "stage-3"],

--- a/babel-preset-r29/package.json
+++ b/babel-preset-r29/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-r29",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Babel preset for Refinery29",
   "main": "index.js",
   "repository": "https://github.com/refinery29/js-standards/tree/master/babel-preset-r29",


### PR DESCRIPTION
Loose mode transpiles ES6 code to ES5 code that is less faithful to ES6 semantics. 

Source: http://2ality.com/2015/12/babel6-loose-mode.html

We have been using this in Rosetta for a few months, and I wanted to move away from it because it's unnecessary and can supposedly lead to problems down the road.

However, upon turning it off I found a 5% increase in bundle size. It seems like a side effect of loose mode is less code. Therefore I'd like to have it as a usable option for our preset as well.