### PR TITLE
switch from preset-es2015 to basic preset-env config

### DIFF
--- a/babel-preset-r29/CHANGELOG.md
+++ b/babel-preset-r29/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0 (January 05, 2018)
+
+* Use `babel-preset-env` in place of `babel-preset-es2015`
+
 ## 1.2.0 (September 22, 2017)
 
 * Allow [loose](https://babeljs.io/docs/plugins/preset-es2015/#optionsloose) ES2015 option to be passed through

--- a/babel-preset-r29/index.js
+++ b/babel-preset-r29/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
 module.exports = function (context, opts = {}) {
-  var es2015 = ['es2015', {}];
+  var env = ['env', {}];
   if (opts.modules !== undefined) {
-    es2015[1].modules = opts.modules;
+    env[1].modules = opts.modules;
   }
   if (opts.loose !== undefined) {
-    es2015[1].loose = opts.loose;
+    env[1].loose = opts.loose;
   }
 
   return {
-    presets: [es2015, "react", "stage-3"],
+    presets: [env, "react", "stage-3"],
     plugins: ["transform-class-properties"]
   };
 };

--- a/babel-preset-r29/package.json
+++ b/babel-preset-r29/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/refinery29/js-standards/tree/master/babel-preset-r29#readme",
   "dependencies": {
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1"
   }

--- a/babel-preset-r29/package.json
+++ b/babel-preset-r29/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-r29",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Babel preset for Refinery29",
   "main": "index.js",
   "repository": "https://github.com/refinery29/js-standards/tree/master/babel-preset-r29",


### PR DESCRIPTION
based on https://babeljs.io/env/, even without getting deeper into `babel-preset-env` config, we should be able to move to `env` in place of `es2015` -- it will include the same transforms