### PR TITLE
babel-preset-r29: allow us to target Node as an environment

### DIFF
--- a/babel-preset-r29/README.md
+++ b/babel-preset-r29/README.md
@@ -20,6 +20,18 @@ npm install --save-dev babel-preset-r29
 }
 ```
 
+or, with some of our [supported options](#supported-options):
+
+```json
+{
+  "presets": [
+    "r29", {
+      "node": true
+    }
+  ]
+}
+```
+
 ### Via CLI
 
 ```sh
@@ -35,6 +47,12 @@ require("babel-core").transform("code", {
 ```
 
 ### Supported options
+#### node
+`boolean`, defaults to `false`.
+
+Targets Node v6 instead of browsers. Useful for avoiding the inclusion of
+unnecessary things like the regenerator runtime in our server builds.
+
 #### loose
 `boolean`, defaults to `false`.
 
@@ -48,8 +66,8 @@ In practice we have found that this can reduce bundle size by ~5%.
 
 Enable transformation of ES6 module syntax to another module type.
 
-Setting this to false will not transform modules. Use this for Webpack 2,
-since Webpack 2's tree-shaking works best if you don't transform `import`/`export`
+Setting this to false will not transform modules. Use this for Webpack >=2,
+since Webpack >=2's tree-shaking works best if you don't transform `import`/`export`
 statements.
 
 Example of a Webpack config where this is the case:

--- a/babel-preset-r29/index.js
+++ b/babel-preset-r29/index.js
@@ -2,6 +2,10 @@
 
 module.exports = function (context, opts = {}) {
   var env = ['env', {}];
+
+  if (opts.node === true) {
+    env[1].targets = { node: '6.13' };
+  }
   if (opts.modules !== undefined) {
     env[1].modules = opts.modules;
   }


### PR DESCRIPTION
When we're building bundles that run on Node, we don't need everything in the configuration we're using right now. As a reminder, that's `babel-preset-env` with no params, which is "exactly the same as babel-preset-latest (or babel-preset-es2015, babel-preset-es2016, and babel-preset-es2017 together)".

For example, Node v6 can understand generator functions, so we don't need the regenerator runtime to be included.

When we upgrade Node versions, we can bump up the version of Node that we're targeting in this repo, and have it easily trickle down to all of our bundles.

Example of this in action, in Rosetta:

Before:
```
Asset     Size  Chunks                    Chunk Names
server.bundle.js  7.15 MB       0  [emitted]  [big]  main

carlo:rosetta carlo.francisco$ grep -r "regeneratorRuntime" build/server.bundle.js
build/server.bundle.js:var hadRuntime = g.regeneratorRuntime &&
build/server.bundle.js:  Object.getOwnPropertyNames(g).indexOf("regeneratorRuntime") >= 0;
build/server.bundle.js:// Save the old regeneratorRuntime in case it needs to be restored later.
build/server.bundle.js:var oldRuntime = hadRuntime && g.regeneratorRuntime;
build/server.bundle.js:g.regeneratorRuntime = undefined;
build/server.bundle.js:  g.regeneratorRuntime = oldRuntime;
build/server.bundle.js:    delete g.regeneratorRuntime;
build/server.bundle.js:    g.regeneratorRuntime = undefined;
build/server.bundle.js:  var runtime = global.regeneratorRuntime;
build/server.bundle.js:      // If regeneratorRuntime is defined globally and we're in a module,
build/server.bundle.js:      // make the exports object identical to regeneratorRuntime.
build/server.bundle.js:  runtime = global.regeneratorRuntime = inModule ? module.exports : {};
build/server.bundle.js:  // `yield regeneratorRuntime.awrap(x)`, so that the runtime can test
carlo:rosetta carlo.francisco$
```

After:
```
Asset     Size  Chunks                    Chunk Names
server.bundle.js  6.92 MB       0  [emitted]  [big]  main

carlo:rosetta carlo.francisco$ grep -r "regeneratorRuntime" build/server.bundle.js
carlo:rosetta carlo.francisco$
```