### PR TITLE
babel-preset-r29 3.0.0

### DIFF
--- a/babel-preset-r29/CHANGELOG.md
+++ b/babel-preset-r29/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0 (January 24, 2019)
+
+* Require Babel 7 and update dependencies
+
 ## 2.1.0 (March 28, 2018)
 
 * Allow `node: true` option, so that we can target Node v6

--- a/babel-preset-r29/package-lock.json
+++ b/babel-preset-r29/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-r29",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/babel-preset-r29/package.json
+++ b/babel-preset-r29/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-r29",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Babel preset for Refinery29",
   "main": "index.js",
   "repository": "https://github.com/refinery29/js-standards/tree/master/babel-preset-r29",


### PR DESCRIPTION
**Updates:**
- Configures `babel-preset-r29` to work with [Babel 7](https://babeljs.io/docs/en/v7-migration) (https://github.com/refinery29/js-standards/pull/22)